### PR TITLE
fix: 公众号页面引入微信JS-SDK后也会有wx对象，原isWeapp判断方法不够准确

### DIFF
--- a/packages/cax/src/common/util.js
+++ b/packages/cax/src/common/util.js
@@ -52,6 +52,6 @@ const root = getGlobal()
 export default{
   getImageInWx,
   root,
-  isWeapp: typeof wx !== 'undefined' && !wx.createCanvas,
+  isWeapp: typeof wx !== 'undefined' && !wx.createCanvas && wx.createCanvasContext,
   isWegame: typeof wx !== 'undefined' && wx.createCanvas
 }


### PR DESCRIPTION
小程序中有wx.createCanvasContext方法但微信JS-SDK中没有，故多加一个判断条件

ps: examples和raf里的isWeapp没做修改